### PR TITLE
restricting scipy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ scikit-learn
 unidecode
 wordcloud
 feedparser
+scipy<1.13


### PR DESCRIPTION
restricting scipy version to avoid triu import error message: https://stackoverflow.com/questions/78279136/importerror-cannot-import-name-triu-from-scipy-linalg-gensim